### PR TITLE
3.14mods

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -21,6 +21,7 @@ vpath %.cpp $(USR_VPATH) $(ALL_SRC_DIRS)
 vpath %.C $(USR_VPATH) $(ALL_SRC_DIRS)
 vpath %.rc $(USR_VPATH) $(ALL_SRC_DIRS)
 vpath %.h $(USR_VPATH) $(ALL_SRC_DIRS)
+vpath %.hpp $(USR_VPATH) $(ALL_SRC_DIRS)
 vpath %.H $(USR_VPATH) $(ALL_SRC_DIRS)
 vpath %.skel.static $(USR_VPATH) $(ALL_SRC_DIRS)
 vpath %.y $(USR_VPATH) $(ALL_SRC_DIRS)
@@ -146,7 +147,7 @@ clean::
 	$(ECHO) "Cleaning"
 	@$(RM) *.i *$(OBJ) *.a $(TESTPRODNAME) $(LIBNAME) $(SHRLIBNAME) \
 	$(INC) $(TARGETS) $(DLL_LINK_LIBNAME) $(TDS) \
-	*.out MakefileInclude  $(LOADABLE_SHRLIBNAME) *.manifest *.exp \
+	*.out MakefileInclude  $(LOADABLE_SHRLIBNAME) *.manifest *.exp *.pdb \
 	$(COMMON_INC) $(HDEPENDS_FILES) $(PRODTARGETS) \
 	$(TESTSCRIPTS) $(TAPFILES)
 ifdef RES
@@ -393,6 +394,13 @@ $(INSTALL_BIN)/%: ../os/$(OS_CLASS)/%
 	$(ECHO) "Installing os-specific script $@"
 	@$(INSTALL_PRODUCT) -d -m $(BIN_PERMISSIONS) $< $(INSTALL_BIN)
 
+$(INSTALL_BIN)/%.exe: %.exe
+	$(ECHO) "Installing executable file $@"
+	@$(INSTALL_PRODUCT) -d -m $(BIN_PERMISSIONS) $< $(INSTALL_BIN)
+ifeq ($(INSTALL_PDB),YES)
+	@$(INSTALL_PRODUCT) -d -m $(BIN_PERMISSIONS) $(basename $<).pdb $(INSTALL_BIN)
+endif
+
 $(INSTALL_BIN)/%: %
 	$(ECHO) "Installing created file $@"
 	@$(INSTALL_PRODUCT) -d -m $(BIN_PERMISSIONS) $< $(INSTALL_BIN)
@@ -412,6 +420,11 @@ $(INSTALL_LIB)/%.lib: %.lib
 $(INSTALL_SHRLIBS): $(INSTALL_SHRLIB)/%: %
 	$(ECHO) "Installing shared library $@"
 	@$(INSTALL_LIBRARY) -d -m $(SHRLIB_PERMISSIONS) $< $(INSTALL_SHRLIB)
+ifeq ($(SHRLIB_SUFFIX),.dll)
+ifeq ($(INSTALL_PDB),YES)
+	@$(INSTALL_LIBRARY) -d -m $(LIB_PERMISSIONS) $(basename $<).pdb $(INSTALL_SHRLIB)
+endif
+endif
 ifneq ($(SHRLIB_SUFFIX),$(SHRLIB_SUFFIX_BASE))
 ifneq (,$(strip $(SHRLIB_VERSION)))
 	@$(RM) $(subst $(SHRLIB_SUFFIX),$(SHRLIB_SUFFIX_BASE),$@)

--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -50,8 +50,9 @@ WARN_CFLAGS_NO  = -W1
 # -Ox maximum optimizations
 # -GL whole program optimization
 # -Oy- re-enable creation of frame pointers
-OPT_CFLAGS_YES_YES = -Ox -GL -Oy-
-OPT_CFLAGS_YES_NO = -Ox -Oy-
+# -Zi generate program database for debugging information
+OPT_CFLAGS_YES_YES = -Ox -GL -Oy- -Zi
+OPT_CFLAGS_YES_NO = -Ox -Oy- -Zi
 OPT_CFLAGS_YES = $(OPT_CFLAGS_YES_$(OPT_WHOLE_PROGRAM))
 
 #
@@ -112,8 +113,9 @@ WARN_CXXFLAGS_NO  = -W1
 # -Ox maximum optimizations
 # -GL whole program optimization
 # -Oy- re-enable creation of frame pointers
-OPT_CXXFLAGS_YES_YES = -Ox -GL -Oy-
-OPT_CXXFLAGS_YES_NO = -Ox -Oy-
+# -Zi generate program database for debugging information
+OPT_CXXFLAGS_YES_YES = -Ox -GL -Oy- -Zi
+OPT_CXXFLAGS_YES_NO = -Ox -Oy- -Zi
 OPT_CXXFLAGS_YES = $(OPT_CXXFLAGS_YES_$(OPT_WHOLE_PROGRAM))
 
 #
@@ -136,9 +138,13 @@ OBJ_CXXFLAG = -Fo
 STATIC_CXXFLAGS_YES= /MT$(VISC_STATIC_CFLAGS_DEBUG) $(VISC_DLL)
 STATIC_CXXFLAGS_NO= /MD$(VISC_STATIC_CFLAGS_DEBUG) $(VISC_DLL)
 
+VISC_NODEFLIB_DEBUG_NO =
+VISC_NODEFLIB_DEBUG_YES = d
 STATIC_LDLIBS_YES=ws2_32.lib advapi32.lib user32.lib kernel32.lib winmm.lib
 STATIC_LDLIBS_NO=
 STATIC_LDFLAGS=
+STATIC_LDFLAGS_EXTRA_YES=/NODEFAULTLIB:MSVCRT.LIB /NODEFAULTLIB:MSVCRTD.LIB /NODEFAULTLIB:LIBCMT$(VISC_NODEFLIB_DEBUG_$(HOST_OPT)).LIB
+STATIC_LDFLAGS_EXTRA_NO=/NODEFAULTLIB:LIBCMT.LIB /NODEFAULTLIB:LIBCMTD.LIB /NODEFAULTLIB:MSVCRT$(VISC_NODEFLIB_DEBUG_$(HOST_OPT)).LIB
 RANLIB=
 
 # add -profile here to run the ms profiler
@@ -149,7 +155,7 @@ RANLIB=
 # -debug generate debugging info
 LINK_OPT_FLAGS_WHOLE_YES = -LTCG
 LINK_OPT_FLAGS_YES = $(LINK_OPT_FLAGS_WHOLE_$(OPT_WHOLE_PROGRAM))
-LINK_OPT_FLAGS_YES += -incremental:no -opt:ref
+LINK_OPT_FLAGS_YES += -debug -incremental:no -opt:ref
 LINK_OPT_FLAGS_YES += -release $(PROD_VERSION:%=-version:%)
 LINK_OPT_FLAGS_NO = -debug -incremental:no -fixed:no
 OPT_LDFLAGS = $(LINK_OPT_FLAGS_$(HOST_OPT))
@@ -283,7 +289,7 @@ SHRLIB_LDLIBS += $(addsuffix .lib, \
 
 #--------------------------------------------------
 # Linker definition
-LINK.cpp = $(WINLINK) -nologo $(STATIC_LDFLAGS) $(LDFLAGS) $(PROD_LDFLAGS) \
+LINK.cpp = $(WINLINK) -nologo $(STATIC_LDFLAGS) $(STATIC_LDFLAGS_EXTRA_$(STATIC_BUILD)) $(LDFLAGS) $(PROD_LDFLAGS) \
     -out:$@ $(call PATH_FILTER, $(PROD_LD_OBJS) $(PROD_LD_RESS) $(PROD_LDLIBS))
 
 #--------------------------------------------------

--- a/src/as/asLib_lex.l
+++ b/src/as/asLib_lex.l
@@ -68,7 +68,7 @@ INP{link} {
 \n      { line_num ++;}
 
 .	{
-	char message[20];
+	char message[22];
 	YY_BUFFER_STATE *dummy=0;
 
 	sprintf(message,"invalid character '%c'",yytext[0]);


### PR DESCRIPTION
•Always build pdb files and install if INSTALL_PDB=YES
•pass additional /NODEFAULTLIB flags to link

(the /NODEFAULTLIB may be a little risky to release into the wild, but I needed it for building (or debugging) something at one point - I just don't recall what at the moment)
